### PR TITLE
Flatpak: home:ro + LUT save via file dialog

### DIFF
--- a/blitz/layout/main.py
+++ b/blitz/layout/main.py
@@ -1617,15 +1617,15 @@ class MainWindow(QMainWindow):
                     f"appropriately structured '.json' file. Error: {e}", color="red")
 
     def save_lut(self) -> None:
-        path = QFileDialog.getExistingDirectory(
-            caption="Choose LUT File Location",
-            directory=str(self.last_file_dir),
+        file, _ = QFileDialog.getSaveFileName(
+            caption="Save LUT File",
+            directory=str(self.last_file_dir / "lut_config.json"),
+            filter="JSON (*.json)",
         )
-        if path:
+        if file:
             lut_config = self.ui.image_viewer.get_lut_config()
-            file = Path(path) / "lut_config.json"
             with open(file, "w", encoding="utf-8") as f:
-                lut_config = json.dump(
+                json.dump(
                     lut_config,
                     f,
                     ensure_ascii=False,

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -45,6 +45,13 @@ Default sandbox has no raw camera devices. To enable USB webcam:
 flatpak override --user --device=all engineering.mess.Blitz
 ```
 
+### Filesystem
+
+The manifest uses `--filesystem=home:ro` so Drag-and-Drop / open of datasets
+under `$HOME` works. Exports use `QFileDialog.getSaveFileName` (XDG portal).
+Flathub requires a linter exception for `home:ro` — justify with DnD from the
+file manager for scientific image folders.
+
 ## Regenerating Python dependency modules
 
 PyQt6 comes from `com.riverbankcomputing.PyQt.BaseApp` — it must **not** be in `requirements-flatpak.txt`.

--- a/flatpak/engineering.mess.Blitz.yml
+++ b/flatpak/engineering.mess.Blitz.yml
@@ -30,10 +30,11 @@ finish-args:
   - --socket=wayland
   - --device=dri
   - --share=network
-  - --filesystem=home
+  - --filesystem=home:ro
   # Webcam (OpenCV /dev/video*): enable with:
   #   flatpak override --user --device=all engineering.mess.Blitz
-
+  # home:ro — DnD/open datasets under $HOME (Flathub exception with rationale).
+  # Writes use QFileDialog getSaveFileName (portal); no write into dropped folders.
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
 


### PR DESCRIPTION
## Summary
- Flatpak finish-arg `--filesystem=home` → `--filesystem=home:ro` (DnD/open datasets; Flathub exception with rationale)
- LUT export uses `QFileDialog.getSaveFileName` instead of writing into a chosen directory

## Test plan
- [ ] Open folder / DnD under `$HOME` still works in Flatpak
- [ ] LUT Export opens save-file dialog and writes the chosen JSON
- [ ] `flatpak-builder-lint` reports only expected `finish-args-home-ro-filesystem-access` (+ optional runtime 6.11 warning)


Made with [Cursor](https://cursor.com)