### PR TITLE
Release 2.0.4

### DIFF
--- a/data/engineering.mess.BLITZ.metainfo.xml
+++ b/data/engineering.mess.BLITZ.metainfo.xml
@@ -37,7 +37,7 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="2.0.3" date="2026-07-27"/>
+    <release version="2.0.4" date="2026-07-28"/>
   </releases>
   <content_rating type="oars-1.1"/>
   <categories>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "BLITZ"
-version = "2.0.2"
+version = "2.0.4"
 description = "Bulk Loading and Interactive Time series Zonal analysis"
 authors = [
     { name = "Philipp Mattern", email = "mattern@mess.engineering" },


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` and AppStream release to **2.0.4** (includes dataset/converter move on main)

## Follow-up
- After merge: tag `v2.0.4` and pin `flatpak/engineering.mess.BLITZ.yml` to that commit

## Test plan
- [ ] Version strings read 2.0.4 in pyproject + metainfo


Made with [Cursor](https://cursor.com)