### PR TITLE
Pin Flatpak source to v2.0.4

### DIFF
--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -76,7 +76,7 @@ Match `--runtime` to the manifest `runtime-version` / SDK branch.
    File: `https://mess.engineering/.well-known/org.flathub.VerifiedApps.txt`
    (path reserved; paste the Developer Portal token after the app exists on Flathub).
 
-2. **Pinned source:** `engineering.mess.BLITZ.yml` already uses git tag `v2.0.2`.
+2. **Pinned source:** `engineering.mess.BLITZ.yml` already uses git tag `v2.0.4`.
    When shipping a new release, bump `tag` and `commit` together.
 
 3. Fork [flathub/flathub](https://github.com/flathub/flathub), open a PR against

--- a/flatpak/engineering.mess.BLITZ.yml
+++ b/flatpak/engineering.mess.BLITZ.yml
@@ -58,5 +58,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/PiMaV/BLITZ.git
-        tag: v2.0.3
-        commit: 0f0fac9773d4f1fefc77e5f5f33605f08a5ac179
+        tag: v2.0.4
+        commit: 20bf5dba9c28a2154847ea733b847091060f1972


### PR DESCRIPTION
## Summary
- Point Flatpak manifest at annotated tag `v2.0.4` / release commit on main

## Test plan
- [ ] `git rev-parse v2.0.4` matches manifest `commit:`


Made with [Cursor](https://cursor.com)