### PR TITLE
Release 2.0.6: export dialog, npy/8-bit, drag rate-limit

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,43 +1,135 @@
 # TODO / Roadmap
 
-## Known Issues (Bugs)
+Prioritized after a long break: **P0 first**, then bugs people feel daily, then features, then architecture, then open ideas.
+Human-readable notes under each item so we remember *what* and *why* without re-diving into the code.
 
-- Statusleiste wurde kaputt gemacht und muss erst gefixt werden bevor wir pushen
-- BLITZ nach WOLKE sync macht noch komische Dinge: es gibt ein Delay und BLITZ ist auch kurz "busy" was eigentlihc nicht sein sollte, da er die matrix ja schon da hat; wenn er nachlädt wäre da sbizarr
+WOLKE-related work lives in its own section at the bottom — **no priority**, keep it separate from the BLITZ core queue.
 
-- Farb patch ist in Colorscale und nicht in RGB (Histgram auch)
+Related: [`docs/missing_features.md`](docs/missing_features.md) (hidden UI / concepts).
 
-- Envelops in RGB ausschalten?
+---
 
-## High Priority Features
+## P0 — Before the next push
 
-*   **DataSource Interface:** Unified interface for Loaders, Converters, and Handlers. Foundation for future plugins.
-*   **Loader Registry:** Registry for extensible loaders.
-*   **Polyline Intensity Profile:** Add a window/dock to display intensity distribution over a drawn polyline.
+### Status bar broken
+The bottom status bar (and the top-left status dock) were heavily reworked when logging moved into its own Log tab. Something in that refactor left the status UI in a bad state. **Fix this before pushing.**
 
-## Medium Priority
+Relevant: `blitz/layout/ui.py` (`setup_menu_and_status_bar`), `blitz/layout/main.py` (`update_statusbar`).
 
-*   **Auto-Crop (Load Dialog):** Bounding box of content on MAX preview. Optional: isoline at threshold (user spinner 0-255) for visual feedback; margin % spinner; ROI updates on spinner change. No auto-apply on load (user controls). Simple threshold (flat > value) on MAX should work well.
-*   **Dual-Build Setup:** Ability to build Standard and Full EXE (= Exotic Data flavours).
-*   **Proper Exporter:** Dialog with Options to export as *.npy or image for Raw / Pipeline / PCA data
-*   **RoSEE:** Check Isolines and normalization (Autozoom should activate).
-*   **Mouse Wheel Zoom:** Allow zooming only on one axis (in extraction plots?).
-* Check Docker build
+---
 
-## Low Priority / Long Term / Discussion
+## P1 — Bugs / UX you notice every day
 
-*   **Project Files:** Restore Load/Save project file functionality in a different way than before?. See `docs/missing_features.md`.
+### Color swatch shows LUT color, not real RGB
+The little color patch at the cursor is filled from the **colorscale / LUT gradient**, not from the actual pixel RGB. The text may show real values, but the chip follows the colormap — misleading on RGB data (and the histogram side has the same LUT-driven feel). Prefer a true-color swatch when the image is RGB.
 
-- LUT autorefresh / zoom?
-- PCA Compoenten Table smaller 
-- Binary Mask Eval?
-- reintroduce pickle for numpy?
-- if data is grayscale, but image is rgb or such: identify from first image and simply load only first channel? Just as quick check
-- would it be nice to have a point within the main view if we are hovering along the vert and horz splines?
-- Woudl it be ncie to have the envolope of the splines wtihin the main view?
-- what about 3D? one could "simple" add an option to view 3D as a checkbox; should actually not be that complex for a first shot
-- Calculating Mean should be checked; is kind of "slow" compared to the other OPs with small data sets
+Relevant: `blitz/layout/main.py` (`_update_position_display`), tooltip currently says “LUT-mapped”.
 
-## Notes on "Missing" Features
+### Mixed image sizes in one folder
+Preview/load fails or soft-errors when frames in a folder have different HxW. Suffix majority alone is not enough. Planned: open a load dialog *before* stacking and let the user choose:
+- **(A)** crop everything to the smallest common HxW (centered), or
+- **(B)** pick a stub/reference frame and crop/align the others to it.
 
-See [`docs/missing_features.md`](docs/missing_features.md) for details on features that are hidden, deactivated, or planned for the "Full" build (e.g., OMERO, DICOM, Crop Widget).
+Then preview and full load both use that strategy.
+
+Relevant: `blitz/data/load.py`, load dialogs in `blitz/layout/dialogs.py`.
+
+### Envelopes on RGB — disable?
+H/V extraction envelopes (min/max over the stack) also run on RGB and collapse over channels. On color data that is often noisy or ambiguous. Open question: turn envelopes off for RGB, or force a grayscale reduction first?
+
+Relevant: `docs/extraction_envelopes.md`, `ExtractionPlot` in `blitz/layout/widgets.py`.
+
+---
+
+## P2 — Features with clear user value
+
+### Polyline intensity profile
+Add a dock/window that shows intensity along a drawn polyline. We already have `PolyLineROI` for measuring geometry (area, length, bbox) — this would sample intensity along an arbitrary path (edges, filaments), not only the H/V crosshairs.
+
+### Auto-crop in the load dialog
+On the MAX preview: suggest a content bounding box via a simple threshold (`> value`, spinner 0–255), optional isoline for feedback, margin % spinner; ROI updates as the user tweaks it. **Do not auto-apply on load** — user stays in control.
+
+### Mouse-wheel zoom on one axis only
+In extraction plots (and similar), allow zooming only X or only Y with the wheel. Timeline already locks Y; extraction plots still use default linked ViewBoxes and fight cumulative zoom-out.
+
+### RoSEE: isolines + normalization
+Check that isolines and Normalize still behave after the isoline split into `IsolineAdapter`. Autozoom should kick in when appropriate so plots don’t sit on a wrong scale after normalize.
+
+Relevant: `blitz/layout/rosee.py`, `blitz/layout/isoline.py`.
+
+### Image smoothing (lost idea — restore to backlog)
+There was once a note about **image smoothing** (spatial blur / similar on the displayed stack) that never made it into a proper todo and got dropped (e.g. via stash during Flatpak work). Today we only smooth inside RoSEE / isolines / TOF curves — not as a general Ops/display tool. Worth deciding: Gaussian (we already use `cv2.GaussianBlur` for isolines), box, or temporal kernels beyond the existing sliding window. See also `docs/numba_candidates.md` (Gaussian / median sliding filters as future).
+
+---
+
+## P3 — Architecture / packaging
+
+### DataSource interface + Loader registry (loaders only)
+A common contract for **loaders** (and maybe handlers), plus a registry suffix → loader. Converters and exotic formats stay **outside** BLITZ as suite add-ons (`CONVERTERS/` etc.) — not part of a “Full” in-app build anymore.
+
+Relevant: `docs/sources_and_variants.md` (parts of this doc are outdated; dual-build story below).
+
+### Dual-build (Standard vs Full) — obsolete
+No longer state of the art for this project. Converters / OMERO / DICOM and similar live as **external add-ons**, not as a second EXE. The only remaining dual-build angles would be things like **GPU vs CPU** or **SP vs MP** — and those paths are effectively **fused** already (multicore thresholds, shared codepaths). Don’t plan Standard/Full packaging unless a real GPU split appears.
+
+### Docker vs Flatpak
+Docker browser packaging becomes uninteresting once **Flatpak** is the Linux distribution path. Prefer Flatpak/Flathub; treat Docker as legacy / optional, not an active roadmap item. See `flatpak/README.md`.
+
+---
+
+## P4 — Backlog / discussion
+
+### Project files (`.blitz`) — rethink, don’t just restore
+Code can still open `.blitz`; the old auto load/save UI was removed on purpose. Effective use needs a rethink:
+- Under **Flatpak**, sibling writes / dataset-relative paths are awkward or broken.
+- Users repeatedly asked **what that file is doing in their data folder** — silent project files next to the images are confusing, not helpful.
+
+Keep commenting / documenting the idea if useful, but default should not be “drop a mystery file next to the dataset.” Prefer XDG config / explicit Save As / or drop the concept.
+
+See `docs/missing_features.md`, `docs/settings.md`.
+
+### LUT auto-refresh / zoom?
+Should LUT levels refresh automatically on frame change or zoom, or stay manual Fit / Auto-fit? Large dynamic-range data makes this a recurring friction point.
+
+### PCA components table — smaller
+Table was already compacted once; Options dock is still tight vs. the variance plot. Shrink further or reclaim vertical space.
+
+### Binary mask eval?
+“Load binary image” applies a boolean mask; mismatches soft-fail with a log line. “Eval” might mean better validation (shape/grayscale) or clearer feedback when the mask does not apply.
+
+### Reintroduce pickle for NumPy?
+`.npy` loads with `allow_pickle=False` (safer, especially for network downloads). Some older/scientific files need pickle for object arrays — maybe an explicit opt-in.
+
+### Gray-looking RGB → take first channel
+We already detect “effectively grayscale” RGB. Quick path: if it is gray-in-RGB, load only channel 0 instead of a full luminance conversion (faster, less RAM).
+
+### Crosshair hover → point in main view
+While scrubbing along the H/V extraction curves, show a corresponding point in the main image so plot position and image stay linked.
+
+### Envelope of the crosshairs in the main view
+Draw envelope bands (min/max or percentile) onto the main image, not only in the H/V plots. Envelope math already exists for the plots.
+
+### Optional 3D view
+Checkbox for a simple 3D/volume view of the time stack. Concept only — would pull in GL deps; “not that complex for a first shot,” but unscoped.
+
+### Mean feels slow on small datasets
+Reduce → Mean is Numba-accelerated, but with small data the BUSY/UI pipeline overhead can dominate, so it feels slower than other ops. Worth profiling whether we flash busy too eagerly or recompute twice.
+
+---
+
+## WOLKE (no priority)
+
+Track separately from the BLITZ core queue. Pick up when the network/sync story is in focus — not ordered against P0–P4.
+
+### Sync feels laggy / briefly “busy”
+When WOLKE only changes the selected frame and BLITZ already has the matrix in memory, sync should be cheap. Today it still goes through a full-ish refresh (`set_image` → `reset_options` → `apply_ops`), so you get a delay and a short BUSY flash even though nothing needs reloading. Reloading the matrix here would be wrong — short-circuit to an index/UI update.
+
+Relevant: `blitz/data/web.py` (selection shortcut), `blitz/layout/main.py` (`end_web_connection`).
+
+---
+
+## Notes
+
+Hidden UI (crop widget) and pure concepts (autograd, ML broken-file detection) live in [`docs/missing_features.md`](docs/missing_features.md) — not duplicated here as active todos.
+
+`docs/sources_and_variants.md` still describes Standard/Full EXE packaging; treat that as historical until the doc is updated to match “add-ons outside + Flatpak.”

--- a/blitz/data/load.py
+++ b/blitz/data/load.py
@@ -174,7 +174,23 @@ def get_image_preview(
                     collected.append(img)
             if not collected:
                 return None
-            stack = np.stack(collected)
+            shapes = {a.shape for a in collected}
+            if len(shapes) > 1:
+                # Mixed sizes: full load-dialog strategy is TODO; do not crash preview.
+                log(
+                    "Preview skipped: images in folder have different sizes. "
+                    "Mixed-size load options are planned (see TODO).",
+                    color="yellow",
+                )
+                return None
+            try:
+                stack = np.stack(collected)
+            except ValueError:
+                log(
+                    "Preview skipped: cannot stack sampled images (shape mismatch).",
+                    color="yellow",
+                )
+                return None
             out = np.max(stack, axis=0).astype(np.uint8)
 
     if normalize and out.size > 0:

--- a/blitz/layout/export_dialog.py
+++ b/blitz/layout/export_dialog.py
@@ -1,0 +1,276 @@
+"""BLITZ export dialog: current frame, frame range, or full stack (.npy).
+
+One UI for all environments. Frame-range prefers individual images into a
+folder (native / GitHub artifact). Under Flatpak (home:ro + portal), sibling
+files are not reliably writable — same dialog falls back to one ZIP and
+tells the user why.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import zipfile
+from enum import Enum
+from pathlib import Path
+
+import numpy as np
+from PyQt6.QtWidgets import (
+    QButtonGroup,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QFormLayout,
+    QLabel,
+    QMessageBox,
+    QRadioButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..tools import log
+
+
+def running_in_flatpak() -> bool:
+    """True inside a Flatpak sandbox (FLATPAK_ID is set by the runtime)."""
+    return bool(os.environ.get("FLATPAK_ID"))
+
+
+class ExportMode(Enum):
+    CURRENT = "current"
+    RANGE = "range"
+    STACK_NPY = "stack_npy"
+
+
+class ExportDialog(QDialog):
+    """Choose what to export. Destination UI adapts to Flatpak vs native."""
+
+    def __init__(self, n_frames: int, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Export")
+        self._n_frames = max(1, n_frames)
+        self._flatpak = running_in_flatpak()
+
+        layout = QVBoxLayout(self)
+        self.hint = QLabel()
+        self.hint.setWordWrap(True)
+        layout.addWidget(self.hint)
+
+        self.radio_current = QRadioButton("Current frame (image)")
+        self.radio_range = QRadioButton("Frame range (numbered images)")
+        self.radio_npy = QRadioButton("Full stack (.npy)")
+        self.radio_current.setChecked(True)
+        group = QButtonGroup(self)
+        for r in (self.radio_current, self.radio_range, self.radio_npy):
+            group.addButton(r)
+            layout.addWidget(r)
+
+        form = QFormLayout()
+        self.spin_start = QSpinBox()
+        self.spin_end = QSpinBox()
+        for sp in (self.spin_start, self.spin_end):
+            sp.setMinimum(0)
+            sp.setMaximum(self._n_frames - 1)
+        self.spin_end.setValue(self._n_frames - 1)
+        form.addRow("First frame", self.spin_start)
+        form.addRow("Last frame", self.spin_end)
+
+        self.cmb_ext = QComboBox()
+        self.cmb_ext.addItems(["png", "jpg", "jpeg", "tif", "bmp"])
+        form.addRow("Image format", self.cmb_ext)
+        layout.addLayout(form)
+
+        self.radio_current.toggled.connect(self._sync_ui)
+        self.radio_range.toggled.connect(self._sync_ui)
+        self.radio_npy.toggled.connect(self._sync_ui)
+        self._sync_ui()
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _sync_ui(self) -> None:
+        is_range = self.radio_range.isChecked()
+        is_img = self.radio_current.isChecked() or is_range
+        self.spin_start.setEnabled(is_range)
+        self.spin_end.setEnabled(is_range)
+        self.cmb_ext.setEnabled(is_img)
+
+        if self.radio_npy.isChecked():
+            self.hint.setText("Writes one .npy file with the full loaded stack.")
+        elif self.radio_current.isChecked():
+            self.hint.setText("Writes one image of the current frame (LUT/levels as shown).")
+        elif self._flatpak:
+            self.hint.setText(
+                "Flatpak sandbox: frame range is saved as one ZIP "
+                "(numbered images inside). Individual files next to each other "
+                "are not reliably writable under home:ro."
+            )
+        else:
+            self.hint.setText(
+                "Choose a folder; numbered images are written there "
+                "(frame_000.png, …)."
+            )
+
+    def mode(self) -> ExportMode:
+        if self.radio_npy.isChecked():
+            return ExportMode.STACK_NPY
+        if self.radio_range.isChecked():
+            return ExportMode.RANGE
+        return ExportMode.CURRENT
+
+    def frame_range(self) -> tuple[int, int]:
+        a, b = self.spin_start.value(), self.spin_end.value()
+        return (min(a, b), max(a, b))
+
+    def image_ext(self) -> str:
+        return self.cmb_ext.currentText().lower()
+
+    @property
+    def in_flatpak(self) -> bool:
+        return self._flatpak
+
+
+def _ensure_suffix(path: Path, ext: str) -> Path:
+    ext = ext if ext.startswith(".") else f".{ext}"
+    if path.suffix.lower() != ext.lower():
+        return path.with_suffix(ext)
+    return path
+
+
+def _write_processed_frame(viewer, frame_index: int, dest: Path) -> None:
+    """Save one on-screen frame (levels + LUT) like pyqtgraph ImageView.export."""
+    img = viewer.getProcessedImage()
+    if viewer.hasTimeAxis():
+        viewer.imageItem.setImage(img[frame_index], autoLevels=False)
+    else:
+        viewer.imageItem.setImage(img, autoLevels=False)
+    viewer.imageItem.save(str(dest))
+
+
+def _export_range_as_images(
+    viewer, start: int, end: int, folder: Path, ext: str
+) -> int:
+    width = max(3, len(str(end)))
+    count = 0
+    for i in range(start, end + 1):
+        dest = folder / f"frame_{i:0{width}d}.{ext}"
+        _write_processed_frame(viewer, i, dest)
+        count += 1
+    return count
+
+
+def _export_range_as_zip(
+    viewer, start: int, end: int, zip_path: Path, ext: str
+) -> int:
+    width = max(3, len(str(end)))
+    count = 0
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            for i in range(start, end + 1):
+                frame_path = tmp_path / f"frame.{ext}"
+                _write_processed_frame(viewer, i, frame_path)
+                zf.write(frame_path, arcname=f"frame_{i:0{width}d}.{ext}")
+                count += 1
+    return count
+
+
+def run_export(viewer, parent: QWidget | None = None, last_dir: Path | None = None) -> None:
+    """Show export dialog; frame-range uses folder images or Flatpak ZIP fallback."""
+    if viewer.image is None:
+        log("Nothing to export — no image loaded.", color="red")
+        return
+
+    n_frames = int(viewer.image.shape[0])
+    dlg = ExportDialog(n_frames, parent=parent)
+    if not dlg.exec():
+        return
+
+    mode = dlg.mode()
+    directory = str(last_dir) if last_dir else ""
+    prev_index = int(viewer.currentIndex)
+
+    try:
+        if mode == ExportMode.STACK_NPY:
+            path_str, _ = QFileDialog.getSaveFileName(
+                parent,
+                "Export stack as NumPy",
+                str(Path(directory) / "blitz_stack.npy"),
+                "NumPy (*.npy)",
+            )
+            if not path_str:
+                return
+            out = _ensure_suffix(Path(path_str), ".npy")
+            np.save(out, viewer.image)
+            log(f"Saved stack → {out}", color="green")
+            return
+
+        ext = dlg.image_ext()
+        if mode == ExportMode.CURRENT:
+            path_str, _ = QFileDialog.getSaveFileName(
+                parent,
+                "Export current frame",
+                str(Path(directory) / f"blitz_frame.{ext}"),
+                f"Images (*.{ext});;All files (*)",
+            )
+            if not path_str:
+                return
+            out = _ensure_suffix(Path(path_str), ext)
+            _write_processed_frame(viewer, prev_index, out)
+            log(f"Saved frame {prev_index} → {out}", color="green")
+            return
+
+        # RANGE: native → folder of images; Flatpak → one ZIP + user feedback
+        start, end = dlg.frame_range()
+        if dlg.in_flatpak:
+            msg = (
+                "Running inside Flatpak: the sandbox cannot reliably write "
+                "many sibling image files. The frame range will be saved as "
+                "one ZIP archive with numbered images inside."
+            )
+            log(msg, color="yellow")
+            QMessageBox.information(parent, "Flatpak export", msg)
+            path_str, _ = QFileDialog.getSaveFileName(
+                parent,
+                "Export frame range as ZIP",
+                str(Path(directory) / "blitz_frames.zip"),
+                "ZIP archive (*.zip)",
+            )
+            if not path_str:
+                return
+            out = _ensure_suffix(Path(path_str), ".zip")
+            n = _export_range_as_zip(viewer, start, end, out, ext)
+            log(f"Saved {n} frames ({start}–{end}) as ZIP → {out}", color="green")
+            return
+
+        folder = QFileDialog.getExistingDirectory(
+            parent,
+            "Choose folder for numbered frame images",
+            directory,
+        )
+        if not folder:
+            return
+        out_dir = Path(folder)
+        n = _export_range_as_images(viewer, start, end, out_dir, ext)
+        log(f"Saved {n} frames ({start}–{end}) → {out_dir}/", color="green")
+    except PermissionError as e:
+        log(
+            f"Export failed (permission denied — Flatpak may need a portal path): {e}",
+            color="red",
+        )
+    except OSError as e:
+        log(f"Export failed: {e}", color="red")
+    except Exception as e:
+        log(f"Export failed: {e}", color="red")
+    finally:
+        try:
+            viewer.setCurrentIndex(prev_index)
+            viewer.updateImage()
+        except Exception:
+            pass

--- a/blitz/layout/main.py
+++ b/blitz/layout/main.py
@@ -65,6 +65,7 @@ from ..data.converters import get_ascii_metadata, load_ascii
 from .dialogs import (AsciiLoadOptionsDialog, CropTimelineDialog,
                      ImageLoadOptionsDialog, RealCameraDialog,
                      VideoLoadOptionsDialog)
+from .export_dialog import run_export
 from .isoline import IsolineAdapter
 from .rosee import ROSEEAdapter
 from .simulated_live import SimulatedLiveWidget
@@ -434,10 +435,11 @@ class MainWindow(QMainWindow):
         self.ui.checkbox_rosee_in_image_v.stateChanged.connect(
             self.toggle_rosee
         )
-        self.ui.h_plot._extractionline.sigPositionChanged.connect(
+        # RoSEE is heavy — update when drag ends / timeline moves, not every pixel.
+        self.ui.h_plot._extractionline.sigPositionChangeFinished.connect(
             self.toggle_rosee
         )
-        self.ui.v_plot._extractionline.sigPositionChanged.connect(
+        self.ui.v_plot._extractionline.sigPositionChangeFinished.connect(
             self.toggle_rosee
         )
         self.ui.image_viewer.timeLine.sigPositionChanged.connect(
@@ -1598,8 +1600,11 @@ class MainWindow(QMainWindow):
             self.load(Path(folder_path))
 
     def export(self) -> None:
-        with LoadingManager(self, "Exporting...", blocking_label=self.ui.blocking_status, blocking_delay_ms=0):
-            self.ui.image_viewer.exportClicked()
+        run_export(
+            self.ui.image_viewer,
+            parent=self,
+            last_dir=self.last_file_dir,
+        )
 
     def browse_lut(self) -> None:
         file, _ = QFileDialog.getOpenFileName(
@@ -1623,14 +1628,24 @@ class MainWindow(QMainWindow):
             filter="JSON (*.json)",
         )
         if file:
-            lut_config = self.ui.image_viewer.get_lut_config()
-            with open(file, "w", encoding="utf-8") as f:
-                json.dump(
-                    lut_config,
-                    f,
-                    ensure_ascii=False,
-                    indent=4,
+            try:
+                lut_config = self.ui.image_viewer.get_lut_config()
+                with open(file, "w", encoding="utf-8") as f:
+                    json.dump(
+                        lut_config,
+                        f,
+                        ensure_ascii=False,
+                        indent=4,
+                    )
+                log(f"Saved LUT → {file}", color="green")
+            except PermissionError as e:
+                log(
+                    f"LUT save failed (permission denied — Flatpak may need a "
+                    f"portal path): {e}",
+                    color="red",
                 )
+            except OSError as e:
+                log(f"LUT save failed: {e}", color="red")
 
     def _on_lut_spin_changed(self) -> None:
         """Apply LUT min/max from spinners to histogram."""
@@ -1946,8 +1961,26 @@ class MainWindow(QMainWindow):
             settings.set("path", "")
 
     def load_images(self, path: Path) -> None:
+        # npy / float stacks: never auto-enable 8-bit (0..1 scale destroys °C etc.)
+        is_npy_source = (
+            (path.is_file() and DataLoader._is_array(path))
+            or (
+                path.is_dir()
+                and any(
+                    f.is_file() and DataLoader._is_array(f)
+                    for f in path.iterdir()
+                )
+            )
+        )
+        if is_npy_source:
+            self.ui.checkbox_load_8bit.setChecked(False)
+            log(
+                "NPY source: 8-bit conversion left off so physical values "
+                "(e.g. temperature) stay intact.",
+                color="yellow",
+            )
         # Bei 8-bit / Grayscale Quelle: Checkboxen direkt setzen
-        if (
+        elif (
             DataLoader._is_video(path)
             or (path.is_file() and DataLoader._is_image(path))
             or (path.is_dir() and get_image_metadata(path) is not None)

--- a/blitz/layout/widgets.py
+++ b/blitz/layout/widgets.py
@@ -10,7 +10,7 @@ _PEN_MIN_PER_CROSSHAIR = pg.mkPen((60, 160, 160), width=2)
 _PEN_MAX_PER_CROSSHAIR = pg.mkPen((100, 200, 200), width=2)
 _PEN_MIN_PER_DATASET = pg.mkPen((60, 80, 160), width=2)
 _PEN_MAX_PER_DATASET = pg.mkPen((100, 130, 220), width=2)
-from PyQt6.QtCore import QPointF, QSize, Qt, pyqtSignal
+from PyQt6.QtCore import QPointF, QSize, Qt, QTimer, pyqtSignal
 from PyQt6.QtGui import QKeyEvent, QMouseEvent, QShowEvent, QWheelEvent
 from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QSizePolicy, QVBoxLayout, QWidget, QLineEdit
 
@@ -452,7 +452,15 @@ class ExtractionPlot(pg.PlotWidget):
         super().__init__(plotItem=v_plot_item, background=get_plot_bg(), **kwargs)
 
         self._extractionline = ExtractionLine(viewer=viewer, vertical=vertical)
-        self._extractionline.sigPositionChanged.connect(self.draw_line)
+        # Live graphs while dragging, but rate-limited (~30 fps) to avoid CPU storms
+        # (especially under Flatpak). Heavy envelopes only when not dragging.
+        self._dragging = False
+        self._draw_pending = False
+        self._draw_timer = QTimer(self)
+        self._draw_timer.setSingleShot(True)
+        self._draw_timer.timeout.connect(self._flush_draw_line)
+        self._extractionline.sigPositionChanged.connect(self._on_line_moved)
+        self._extractionline.sigPositionChangeFinished.connect(self._on_line_finished)
         self._viewer.timeLine.sigPositionChanged.connect(self.draw_line)
         self._viewer.image_changed.connect(self.draw_line)
         self._viewer.image_changed.connect(self._invalidate_dataset_envelope_cache)
@@ -467,6 +475,27 @@ class ExtractionPlot(pg.PlotWidget):
         self._dataset_envelope_cache_key: tuple[int, ...] | None = None
         self._stale: bool = False
         self.center_line()
+
+    def _on_line_moved(self, *_args) -> None:
+        self._dragging = True
+        self._draw_pending = True
+        if not self._draw_timer.isActive():
+            self._flush_draw_line()
+
+    def _on_line_finished(self, *_args) -> None:
+        self._dragging = False
+        self._draw_timer.stop()
+        self._draw_pending = False
+        self.draw_line()
+
+    def _flush_draw_line(self) -> None:
+        if not self._draw_pending:
+            return
+        self._draw_pending = False
+        self.draw_line()
+        # Cooldown: further moves coalesce until timer fires again.
+        if self._dragging:
+            self._draw_timer.start(33)
 
     def set_envelope_percentile(self, pct: float) -> None:
         self._envelope_pct = pct
@@ -493,7 +522,8 @@ class ExtractionPlot(pg.PlotWidget):
             size=settings.get("viewer/intersection_point_size"),
         )
         self._extractionline.couple(plot._extractionline)
-        plot._extractionline.sigPositionChanged.connect(self.draw_line)
+        plot._extractionline.sigPositionChanged.connect(self._on_line_moved)
+        plot._extractionline.sigPositionChangeFinished.connect(self._on_line_finished)
         self._coupled = plot
 
     def center_line(self) -> None:
@@ -674,8 +704,12 @@ class ExtractionPlot(pg.PlotWidget):
         if (image := self.extract_data()) is not None:
             self.plot(image)
             self.draw_indicator(image)
-            self._draw_envelope_lines(image)
-            ds_env = self._compute_dataset_envelope() if self._show_envelope_per_dataset else None
+            # During drag: skip expensive envelopes (esp. per-dataset = all frames).
+            ds_env = None
+            if not self._dragging:
+                self._draw_envelope_lines(image)
+                if self._show_envelope_per_dataset:
+                    ds_env = self._compute_dataset_envelope()
             self._fit_unlinked_axis(image, ds_env)
 
     def plot(

--- a/data/engineering.mess.BLITZ.metainfo.xml
+++ b/data/engineering.mess.BLITZ.metainfo.xml
@@ -42,6 +42,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.0.6" date="2026-07-28"/>
     <release version="2.0.5" date="2026-07-28"/>
     <release version="2.0.4" date="2026-07-28"/>
   </releases>

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -76,7 +76,7 @@ Match `--runtime` to the manifest `runtime-version` / SDK branch.
    File: `https://mess.engineering/.well-known/org.flathub.VerifiedApps.txt`
    (path reserved; paste the Developer Portal token after the app exists on Flathub).
 
-2. **Pinned source:** `engineering.mess.BLITZ.yml` already uses git tag `v2.0.5`.
+2. **Pinned source:** `engineering.mess.BLITZ.yml` already uses git tag `v2.0.6`.
    When shipping a new release, bump `tag` and `commit` together.
 
 3. Fork [flathub/flathub](https://github.com/flathub/flathub), open a PR against

--- a/flatpak/engineering.mess.BLITZ.yml
+++ b/flatpak/engineering.mess.BLITZ.yml
@@ -34,7 +34,8 @@ finish-args:
   # Webcam (OpenCV /dev/video*): enable with:
   #   flatpak override --user --device=all engineering.mess.BLITZ
   # home:ro — DnD/open datasets under $HOME (Flathub exception with rationale).
-  # Writes use QFileDialog getSaveFileName (portal); no write into dropped folders.
+  # File→Export: current/stack = one portal file; frame range = folder of
+  # images natively, ZIP fallback inside Flatpak (see export_dialog.py).
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
 

--- a/flatpak/engineering.mess.BLITZ.yml
+++ b/flatpak/engineering.mess.BLITZ.yml
@@ -59,5 +59,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/PiMaV/BLITZ.git
-        tag: v2.0.5
-        commit: 5f706912da1376f6b19de13bdde8866f16b4ae50
+        tag: v2.0.6
+        commit: 8671caac52a74527ac765783ee81a5d041b11e83

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "BLITZ"
-version = "2.0.5"
+version = "2.0.6"
 description = "Bulk Loading and Interactive Time series Zonal analysis"
 authors = [
     { name = "Philipp Mattern", email = "mattern@mess.engineering" },


### PR DESCRIPTION
## Summary
- Own Flatpak-aware File→Export (current / frame-range folder or ZIP fallback / stack `.npy`)
- Soft-fail mixed-size preview; npy leaves 8-bit off; live extraction plots with heavy work on drag end
- Bump to 2.0.6 and pin Flatpak source to `v2.0.6`

## Test plan
- [x] Local Flatpak smoke: export, drag feel
- [ ] GH build deferred (after parallel 2.0.7 work)


Made with [Cursor](https://cursor.com)